### PR TITLE
Change config filename ref to match standard

### DIFF
--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -20,7 +20,7 @@ if not EDXNOTES_CONFIG_ROOT:
 
 CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
 
-with open(CONFIG_ROOT / "edx-notes-api.yml") as yaml_file:
+with open(CONFIG_ROOT / "edx_notes_api.yml") as yaml_file:
     config_from_yaml = yaml.load(yaml_file)
 
 vars().update(config_from_yaml)


### PR DESCRIPTION
The DevOps team recently standardized on underscores, rather than dashes, as filename separators.