### PR TITLE
Search and highlight tags in student notes TNL-1927

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Oleg Marshev <oleg@edx.org>
 Tim Babych <tim.babych@gmail.com>
 Christina Roberts <christina@edx.org>
+Ben McMorran <ben.mcmorran@gmail.com>

--- a/notesapi/v1/search_indexes.py
+++ b/notesapi/v1/search_indexes.py
@@ -12,6 +12,7 @@ class NoteIndex(indexes.SearchIndex, indexes.Indexable):
     created = indexes.DateTimeField(model_attr='created')
     updated = indexes.DateTimeField(model_attr='updated')
     tags = indexes.CharField(model_attr='tags')
+    data = indexes.CharField(use_template=True)
 
     def get_model(self):
         return Note

--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -74,3 +74,7 @@ CORS_ALLOW_HEADERS = (
     'x-csrftoken',
     'x-annotator-auth-token',
 )
+
+TEMPLATE_DIRS = (
+    'templates',
+)

--- a/templates/search/indexes/v1/note_data.txt
+++ b/templates/search/indexes/v1/note_data.txt
@@ -1,0 +1,2 @@
+{{ object.text }}
+{{ object.tags }}


### PR DESCRIPTION
Changes the search query so that notes are a hit if there is a match in the text or tags. Highlights matching tags. Changes the ordering of the search results when running on ElasticSearch from most recently updated to most relevant first.

Please review @cahrens @dan-f 