### PR TITLE
Added support for Elasticsearch 1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ after_success:
 
 env:
 - ESVER=-
-- ESVER=0.90.11
 - ESVER=1.4.2
+- ESVER=1.5.2

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,12 @@ This is a backend store for edX Student Notes.
 Overview
 --------
 
-The edX Notes API is designed to be compatible with the
-`Annotator <http://annotatorjs.org/>`__. Can be run with up to date ElasticSearch or legacy 0.90.x.
+The edX Notes API is designed to be compatible with the `Annotator <http://annotatorjs.org/>`__.
 
 Getting Started
 ---------------
 
-1. You'll need an `ElasticSearch <http://elasticsearch.org>`__ installed.
+1. Install `ElasticSearch <http://elasticsearch.org>`__ 1.x.y.
 
 2. Install the requirements:
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,8 +2,8 @@ Django==1.8.7
 requests==2.4.3
 djangorestframework==3.2.3
 django-rest-swagger==0.2.0
-django-haystack==2.3.1
-elasticsearch==0.4.5  # only 0.4 works for ES 0.90
+django-haystack==2.4.1
+elasticsearch>=1.0.0,<2.0.0
 django-cors-headers==1.1.0
 PyJWT==0.3.0
 MySQL-python==1.2.5  # GPL License


### PR DESCRIPTION
Elasticsearch 0.90.x is quite out-of-date, and this requirement is preventing us from sharing an ES cluster with newer IDAs.

ECOM-3261 and SOL-295

_NOTE: This should NOT be merged until edx/configuration is updated to actually install Elasticsearch 1.5.2 (the latest version supported on AWS) for devstack and sandboxes._

Reviewers: @olmar @muhammad-ammar @dan-f 
FYI: @e0d @cahrens @cpennington 
