### PR TITLE
Adding format tag instead of Klass and span for ES highlight.

### DIFF
--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -679,14 +679,10 @@ class AnnotationSearchViewTests(BaseAnnotationViewTests):
         results = self._get_search_results(text="first", highlight=True)
         self.assertEqual(results['total'], 1)
         self.assertEqual(len(results['rows']), 1)
-        self.assertEqual(results['rows'][0]['text'], '<em>First</em> note')
-
-        results = self._get_search_results(text="first", highlight=True, highlight_tag='tag')
-        self.assertEqual(results['rows'][0]['text'], '<tag>First</tag> note')
-
-        results = self._get_search_results(text="first", highlight=True, highlight_tag='tag', highlight_class='klass')
-        self.assertEqual(results['rows'][0]['text'], '<tag class="klass">First</tag> note')
-
+        self.assertEqual(
+                results['rows'][0]['text'],
+                '{elasticsearch_highlight_start}First{elasticsearch_highlight_end} note'
+        )
 
     @override_settings(ES_DISABLED=True)
     def test_search_ordering_in_db(self):
@@ -861,13 +857,10 @@ class AnnotationSearchViewTests(BaseAnnotationViewTests):
         results = self._get_search_results(text="bar", highlight=True)
         self.assertEqual(results['total'], 1)
         self.assertEqual(len(results['rows']), 1)
-        self.assertEqual(results['rows'][0]['tags'], ['foo', '<em>bar</em>'])
-
-        results = self._get_search_results(text="bar", highlight=True, highlight_tag='tag')
-        self.assertEqual(results['rows'][0]['tags'], ['foo', '<tag>bar</tag>'])
-
-        results = self._get_search_results(text="bar", highlight=True, highlight_tag='tag', highlight_class='klass')
-        self.assertEqual(results['rows'][0]['tags'], ['foo', '<tag class="klass">bar</tag>'])
+        self.assertEqual(
+                results['rows'][0]['tags'],
+                ['foo', '{elasticsearch_highlight_start}bar{elasticsearch_highlight_end}']
+        )
 
     @ddt.unpack
     @ddt.data(

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -145,14 +145,9 @@ class AnnotationSearchView(GenericAPIView):
             query = query.filter(SQ(data=clean_text))
 
         if params.get('highlight'):
-            tag = params.get('highlight_tag', 'em')
-            klass = params.get('highlight_class')
             opts = {
-                'pre_tags': ['<{tag}{klass_str}>'.format(
-                    tag=tag,
-                    klass_str=' class=\\"{}\\"'.format(klass) if klass else ''
-                )],
-                'post_tags': ['</{tag}>'.format(tag=tag)],
+                'pre_tags': ['{elasticsearch_highlight_start}'],
+                'post_tags': ['{elasticsearch_highlight_end}'],
             }
             query = query.highlight(**opts)
 


### PR DESCRIPTION
This PR replaces html tag & class being with format tags`{elasticsearch_highlight_start}`, `{elasticsearch_highlight_end}` for ES highlight feature.

 TNL-4012