### PR TITLE
fix unicode error when search with highlighting

### DIFF
--- a/notesapi/v1/serializers.py
+++ b/notesapi/v1/serializers.py
@@ -56,7 +56,7 @@ class NotesElasticSearchSerializer(serializers.Serializer):  # pylint: disable=a
         Return note text.
         """
         if note.highlighted:
-            return note.highlighted[0].decode('unicode_escape')
+            return note.highlighted[0]
         return note.text
 
     def get_ranges(self, note):

--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -738,6 +738,25 @@ class AnnotationSearchViewTests(BaseAnnotationViewTests):
         response = self._get_search_results(text=u"Свят")
         self.assertEqual(response['rows'][0]['text'], u'Веселих свят')
 
+    @ddt.unpack
+    @ddt.data(
+        {"text": u"Веселих свят", 'text_to_search': u"веселих", 'result': u"{}Веселих{} свят"},
+        {"text": "The Hunger games", 'text_to_search': "Hunger", 'result': "The {}Hunger{} games"}
+    )
+    @unittest.skipIf(settings.ES_DISABLED, "MySQL cannot do highlighting")
+    def test_search_with_highlighting(self, text, text_to_search, result):
+        """
+        Tests searching of unicode and non-unicode text with highlighting enabled.
+        """
+        start_tag = "{elasticsearch_highlight_start}"
+        end_tag = "{elasticsearch_highlight_end}"
+
+        self._create_annotation(text=text)
+
+        response = self._get_search_results(text=text_to_search, highlight=True)
+        self.assertEqual(response['total'], 1)
+        self.assertEqual(response['rows'][0]['text'], result.format(start_tag, end_tag))
+
     def test_search_multiword(self):
         """
         Tests searching of complex words and word combinations


### PR DESCRIPTION
## [TNL-4101](https://openedx.atlassian.net/browse/TNL-4101)

During serialization unicode string is using decode method to decode itself using unicode_escape codec. Which is incorrect because decode method is for byte string not for unicode string.

### Testing
- [x] Unit

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @symbolist 
- [ ] Code review: @muzaffaryousaf

### Post-review
- [ ] Squash commits