### PR TITLE
[TNL-4029] user can't add more than maximum number of allowed notes

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -80,3 +80,6 @@ CORS_ALLOW_HEADERS = (
 TEMPLATE_DIRS = (
     'templates',
 )
+
+### Maximum number of allowed notes per course ###
+MAX_ANNOTATIONS_PER_COURSE = 500

--- a/notesserver/settings/test.py
+++ b/notesserver/settings/test.py
@@ -42,3 +42,6 @@ LOGGING = {
         }
     },
 }
+
+### Maximum number of allowed notes per course ###
+MAX_ANNOTATIONS_PER_COURSE = 5


### PR DESCRIPTION
Throws an error if tried to create more notes per course than defined in settings.
@symbolist @muzaffaryousaf @muhammad-ammar please review