### PR TITLE
[TNL-4029] user can't add more than maximum number of allowed notes

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -83,3 +83,6 @@ TEMPLATE_DIRS = (
 )
 
 DEFAULT_NOTES_PAGE_SIZE = 25
+
+### Maximum number of allowed notes for each student per course ###
+MAX_NOTES_PER_COURSE = 500

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ MySQL-python==1.2.5  # GPL License
 gunicorn==19.1.1     # MIT
 path.py==3.0.1
 python-dateutil==2.4.0
+newrelic==2.40.0.34            # New Relic

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,1 +1,0 @@
-newrelic==2.40.0.34            # New Relic


### PR DESCRIPTION
Throws an error if tried to create more notes per course than defined in settings.
@symbolist @muzaffaryousaf @muhammad-ammar please review