### PR TITLE
Config path for variable edx_notes_api_service_name

### DIFF
--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -19,7 +19,7 @@ if not EDXNOTES_CONFIG_ROOT:
     raise ImproperlyConfigured("EDXNOTES_CONFIG_ROOT must be defined in the environment.")
 
 CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
-CONFIG_FILE = environ.get('EDXNOTES_CONFIG_FILE', 'edx_notes_api.yml')
+CONFIG_FILE = environ.get('SERVICE_VARIANT', 'edx_notes_api')+'.yml'
 
 with open(CONFIG_ROOT / CONFIG_FILE) as yaml_file:
     config_from_yaml = yaml.load(yaml_file)

--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -19,8 +19,9 @@ if not EDXNOTES_CONFIG_ROOT:
     raise ImproperlyConfigured("EDXNOTES_CONFIG_ROOT must be defined in the environment.")
 
 CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
+CONFIG_FILE = os.environ.get('CONFIG_FILE')
 
-with open(CONFIG_ROOT / "edx_notes_api.yml") as yaml_file:
+with open(CONFIG_ROOT / CONFIG_FILE) as yaml_file:
     config_from_yaml = yaml.load(yaml_file)
 
 vars().update(config_from_yaml)

--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -19,7 +19,7 @@ if not EDXNOTES_CONFIG_ROOT:
     raise ImproperlyConfigured("EDXNOTES_CONFIG_ROOT must be defined in the environment.")
 
 CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
-CONFIG_FILE = environ.get('CONFIG_FILE', 'edx_notes_api.yml')
+CONFIG_FILE = environ.get('EDXNOTES_CONFIG_FILE', 'edx_notes_api.yml')
 
 with open(CONFIG_ROOT / CONFIG_FILE) as yaml_file:
     config_from_yaml = yaml.load(yaml_file)

--- a/notesserver/settings/yaml_config.py
+++ b/notesserver/settings/yaml_config.py
@@ -19,7 +19,7 @@ if not EDXNOTES_CONFIG_ROOT:
     raise ImproperlyConfigured("EDXNOTES_CONFIG_ROOT must be defined in the environment.")
 
 CONFIG_ROOT = path(EDXNOTES_CONFIG_ROOT)
-CONFIG_FILE = os.environ.get('CONFIG_FILE')
+CONFIG_FILE = environ.get('CONFIG_FILE', 'edx_notes_api.yml')
 
 with open(CONFIG_ROOT / CONFIG_FILE) as yaml_file:
     config_from_yaml = yaml.load(yaml_file)


### PR DESCRIPTION
Quick fix to notesserver yaml_config Django settings file to allow for variable values of _edx_notes_api_service_name_. My first contribution so keeping it small =)

Ansible edx-service role creates yaml config file based on service name. In notesserver, yaml_config is passing hardcoded 'edx_notes_api.yml' value to config_from_yaml. This results in a file not found error and prevents installation if _edx_notes_api_service_name_ has been set to a non-default value. This fix uses the SERVICE_VARIANT var already being passed to the edx_notes_api.conf.j2 template in the edx_notes_api role to find the correct path.


