### PR TITLE
Support bulk search in /search endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Oleg Marshev <oleg@edx.org>
 Tim Babych <tim.babych@gmail.com>
 Christina Roberts <christina@edx.org>
 Ben McMorran <ben.mcmorran@gmail.com>
+Mushtaq Ali <mushtaak@gmail.com>

--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -680,6 +680,32 @@ class AnnotationSearchViewTests(BaseAnnotationViewTests):
         search_and_verify("First", "First one", [])
         search_and_verify("Second", "Second note", ["tag1", "tag2"])
 
+    @ddt.data(True, False)
+    def test_usage_id_search(self, is_es_disabled):
+        """
+        Verifies the search with usage id.
+        """
+        self._create_annotation(text=u'First one', usage_id='test-1')
+        self._create_annotation(text=u'Second note', usage_id='test-2')
+        self._create_annotation(text=u'Third note', usage_id='test-3')
+
+        @patch('django.conf.settings.ES_DISABLED', is_es_disabled)
+        def verify_usage_id_search(usage_ids):
+            """
+            Verify search results based on usage id operation.
+
+            Arguments:
+                usage_ids: List. The identifier string of the annotations XBlock(s).
+            """
+            results = self._get_search_results(usage_id=usage_ids)
+            self.assertEqual(len(results), len(usage_ids))
+            # Here we are reverse-traversing usage_ids because response has descending ordered rows.
+            for index, u_id in enumerate(usage_ids[::-1]):
+                self.assertEqual(results[index]['usage_id'], u_id)
+
+        verify_usage_id_search(usage_ids=['test-1'])
+        verify_usage_id_search(usage_ids=['test-1', 'test-2', 'test-3'])
+
     def test_search_deleted(self):
         """
         Tests for search method to not return deleted notes.

--- a/notesserver/test_views.py
+++ b/notesserver/test_views.py
@@ -1,3 +1,4 @@
+import json
 import datetime
 from unittest import skipIf
 from mock import patch, Mock
@@ -17,7 +18,7 @@ class OperationalEndpointsTest(APITestCase):
         """
         response = self.client.get(reverse('heartbeat'))
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data, {"OK": True})
+        self.assertEquals(json.loads(response.content), {"OK": True})
 
     @skipIf(settings.ES_DISABLED, "Do not test if Elasticsearch service is disabled.")
     @patch('notesserver.views.get_es')
@@ -28,7 +29,7 @@ class OperationalEndpointsTest(APITestCase):
         mocked_get_es.return_value.ping.return_value = False
         response = self.client.get(reverse('heartbeat'))
         self.assertEquals(response.status_code, 500)
-        self.assertEquals(response.data, {"OK": False, "check": "es"})
+        self.assertEquals(json.loads(response.content), {"OK": False, "check": "es"})
 
     @patch("django.db.backends.utils.CursorWrapper")
     def test_heartbeat_failure_db(self, mocked_cursor_wrapper):
@@ -38,7 +39,7 @@ class OperationalEndpointsTest(APITestCase):
         mocked_cursor_wrapper.side_effect = Exception
         response = self.client.get(reverse('heartbeat'))
         self.assertEquals(response.status_code, 500)
-        self.assertEquals(response.data, {"OK": False, "check": "db"})
+        self.assertEquals(json.loads(response.content), {"OK": False, "check": "db"})
 
     def test_root(self):
         """

--- a/notesserver/views.py
+++ b/notesserver/views.py
@@ -3,6 +3,8 @@ import datetime
 
 from django.db import connection
 from django.conf import settings
+from django.http import JsonResponse
+
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -38,12 +40,12 @@ def heartbeat(request):  # pylint: disable=unused-argument
     try:
         db_status()
     except Exception:
-        return Response({"OK": False, "check": "db"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return JsonResponse({"OK": False, "check": "db"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     if not settings.ES_DISABLED and not get_es().ping():
-        return Response({"OK": False, "check": "es"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return JsonResponse({"OK": False, "check": "es"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    return Response({"OK": True})
+    return JsonResponse({"OK": True}, status=status.HTTP_200_OK)
 
 
 @api_view(['GET'])


### PR DESCRIPTION
### Description
### [TNL-5604](https://openedx.atlassian.net/browse/TNL-5604)
This change adds support to search by multiple usage ids in `/search` end point.
### [TNL-5244](https://openedx.atlassian.net/browse/TNL-5244)
This change also updates `/heartbeat` endpoint to send JSON response by default.
### Testing
- [x] Unit
- [x] Manual
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @muhammad-ammar 
### Post-review
- [x] Squash commits
