### PR TITLE
[DELAY MERGE] TNL-6145: Upgrade ES to 1.x for notes

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_PASSWORD: "secret"
       MYSQL_DATABASE: "edx_notes_api"
   es:
-    image: edxops/elasticsearch:0.9.13
+    image: elasticsearch:1.5.2
     container_name: es
   notes:
     # Uncomment this line to use the official course-discovery base image

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,12 @@ This is a backend store for edX Student Notes.
 Overview
 --------
 
-The edX Notes API is designed to be compatible with the
-`Annotator <http://annotatorjs.org/>`__. Can be run with up to date ElasticSearch or legacy 0.90.x.
+The edX Notes API is designed to be compatible with the `Annotator <http://annotatorjs.org/>`__.
 
 Getting Started
 ---------------
 
-1. You'll need an `ElasticSearch <http://elasticsearch.org>`__ installed.
+1. Install `ElasticSearch 1.5.2 <https://www.elastic.co/blog/elasticsearch-1-5-2-and-1-4-5-released>`__.
 
 2. Install the requirements:
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,8 +2,8 @@ Django==1.8.7
 requests==2.4.3
 djangorestframework==3.2.3
 django-rest-swagger==0.2.0
-django-haystack==2.3.1
-elasticsearch==0.4.5  # only 0.4 works for ES 0.90
+django-haystack==2.6.0
+elasticsearch>=1.0.0,<2.0.0
 django-cors-headers==1.1.0
 PyJWT==0.3.0
 MySQL-python==1.2.5  # GPL License


### PR DESCRIPTION
## [TNL-6145](https://openedx.atlassian.net/browse/TNL-6145)

### Description

This is to upgrade ES to 1.5 for notes.  Mostly, it is about removing support for ES 0.9.

A version of this PR (https://github.com/edx/edx-notes-api/pull/34) already had thumbs, but this also makes haystack a little more up to date and drops ES 1.4 testing.

This will be a slightly longer lasting branch until we are ready for deployment of ES 1.5 everywhere.

### Sandbox
- Not available.

### Testing
- [X] Unit, integration, acceptance tests as appropriate
- [x] Performance

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @maxrothman 
- [x] Code review: @dianakhuang 

FYI: @clintonb 

### Post-review
- [x] Rebase and squash commits [DO NOT MERGE]
