### PR TITLE
Notes API add endpoint to delete all notes for a user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ coverage/
 
 #vim
 *.swp
+
+venv/
+
+.idea/

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -1,22 +1,21 @@
-import logging
 import json
-import newrelic.agent
+import logging
 
+import newrelic.agent
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils.translation import ugettext as _
-
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from haystack.query import SQ
-
 from notesapi.v1.models import Note
-from notesapi.v1.serializers import NoteSerializer, NotesElasticSearchSerializer
+from notesapi.v1.serializers import (NotesElasticSearchSerializer,
+                                     NoteSerializer)
 
 if not settings.ES_DISABLED:
     from notesserver.highlight import SearchQuerySet
@@ -348,6 +347,18 @@ class AnnotationListView(GenericAPIView):
         location = reverse('api:v1:annotations_detail', kwargs={'annotation_id': note.id})
         serializer = NoteSerializer(note)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers={'Location': location})
+
+    def delete(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Delete all annotations for user_id
+
+        """
+        params = self.request.data
+        if 'user_id' not in params:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        Note.objects.filter(user_id=params['user_id']).delete()
+        return Response(status=status.HTTP_200_OK)
 
 
 class AnnotationDetailView(APIView):


### PR DESCRIPTION
## [EDUCATOR-2657](https://openedx.atlassian.net/browse/EDUCATOR-2657)

### Description
Add 'delete all notes for user' endpoint for Notes API. Implements list view delete method.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @sanfordstudent 
- [ ] Code review: @doctoryes 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits


