### PR TITLE
Install release_util for deployment pipeline compliance

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -52,6 +52,8 @@ INSTALLED_APPS = [
     'corsheaders',
     'haystack',
     'notesapi.v1',
+    # additional release utilities to ease automation
+    'release_util',
 ]
 
 STATIC_URL = '/static/'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,3 +11,4 @@ gunicorn==19.1.1     # MIT
 path.py==3.0.1
 python-dateutil==2.4.0
 newrelic==2.40.0.34            # New Relic
+edx-django-release-util==0.3.1


### PR DESCRIPTION
Now that we are trying to deploy this IDA via pipelines, it needs some
extra management commands provided by release_util.

PLAT-2162