### PR TITLE
Use an absolute path for the templates dir

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -80,9 +80,20 @@ CORS_ALLOW_HEADERS = (
     'x-annotator-auth-token',
 )
 
-TEMPLATE_DIRS = (
-    'templates',
-)
+# Base project path, where manage.py lives.
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,  # This ensures app templates are loadable, e.g. DRF views.
+        'DIRS': [
+            # The EdxNotes templates directory is not actually under any app
+            # directory, so specify its absolute path.
+            os.path.join(BASE_DIR, 'templates'),
+        ]
+    }
+]
 
 DEFAULT_NOTES_PAGE_SIZE = 25
 


### PR DESCRIPTION
For some reason, this was necessary for the notes IDA in devstack,
otherwise it would just throw TemplateDoesNotExist.  It's so specific
that it shoudln't impact stage or prod which already seem to work
without this.

Also migrate TEMPLATE_DIRS variable to non-deprecated TEMPLATES
variable.