### PR TITLE
Add pyinotify to improve dev server code reloading

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,3 +10,5 @@ pylint==1.5.0
 diff-cover==0.7.2
 factory_boy==2.5.2
 ddt==0.8.0
+# For devserver code reloading
+pyinotify==0.9.6


### PR DESCRIPTION
On devstack, each IDA consumes ~2% CPU while idle, because of Django's dev server code reloading. Adding the pyinotify library decreases CPU usage to <0.1%

(Continuation of [1547](https://github.com/edx/course-discovery/pull/1547)) 