### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -43,6 +43,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 INSTALLED_APPS = [

--- a/notesserver/settings/devstack.py
+++ b/notesserver/settings/devstack.py
@@ -27,3 +27,4 @@ DATABASES = {
     }
 }
 
+JWT_AUTH = {}

--- a/notesserver/settings/test.py
+++ b/notesserver/settings/test.py
@@ -16,6 +16,8 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 DISABLE_TOKEN_CHECK = False
 INSTALLED_APPS += ('django_nose',)
 
+JWT_AUTH = {}
+
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'notesserver.highlight.ElasticsearchSearchEngine',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,4 +13,4 @@ python-dateutil==2.4.0
 newrelic==2.40.0.34            # New Relic
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.1
+edx-drf-extensions==1.10.0


### PR DESCRIPTION
From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233

Pre-merge:
- [ ] Land configuration change PR: https://github.com/edx/configuration/pull/4821