### PR TITLE
Rename DELETE /api/v1/annotations/ to POST /api/v1/retire_annotations

### DIFF
--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -517,19 +517,19 @@ class AnnotationListViewTests(BaseAnnotationViewTests):
         response = self._get_search_results()
         self.assertEqual(response["total"], 3)
 
-        url = reverse('api:v1:annotations')
+        url = reverse('api:v1:annotations_retire')
         self.payload["user"] = user_id
         # Delete all notes for User 1
-        response = self.client.delete(url, headers=self.headers, data=self.payload)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.post(url, headers=self.headers, data=self.payload)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Verify notes are deleted for User 1
         response = self._get_search_results()
         self.assertEqual(response["total"], 0)
 
         # Reattempt delete for User 1
-        response = self.client.delete(url, headers=self.headers, data=self.payload)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.post(url, headers=self.headers, data=self.payload)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_delete_all_user_annotations_no_user(self):
         """
@@ -545,9 +545,9 @@ class AnnotationListViewTests(BaseAnnotationViewTests):
         response = self._get_search_results()
         self.assertEqual(response["total"], 3)
 
-        url = reverse('api:v1:annotations')
+        url = reverse('api:v1:annotations_retire')
         del self.payload['user']
-        response = self.client.delete(url, headers=self.headers, data=self.payload)
+        response = self.client.post(url, headers=self.headers, data=self.payload)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # Verify no notes are deleted
@@ -568,9 +568,9 @@ class AnnotationListViewTests(BaseAnnotationViewTests):
         response = self._get_search_results()
         self.assertEqual(response["total"], 3)
 
-        url = reverse('api:v1:annotations')
+        url = reverse('api:v1:annotations_retire')
         self.payload["user"] = TEST_OTHER_USER
-        response = self.client.delete(url, headers=self.headers, data=self.payload)
+        response = self.client.post(url, headers=self.headers, data=self.payload)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # Verify no notes are deleted

--- a/notesapi/v1/urls.py
+++ b/notesapi/v1/urls.py
@@ -1,8 +1,14 @@
 from django.conf.urls import url
-from notesapi.v1.views import AnnotationListView, AnnotationDetailView, AnnotationSearchView
+from notesapi.v1.views import (
+    AnnotationDetailView,
+    AnnotationListView,
+    AnnotationRetireView,
+    AnnotationSearchView,
+)
 
 urlpatterns = [
     url(r'^annotations/$', AnnotationListView.as_view(), name='annotations'),
+    url(r'^retire_annotations/$', AnnotationRetireView.as_view(), name='annotations_retire'),
     url(
         r'^annotations/(?P<annotation_id>[a-zA-Z0-9_-]+)/?$',
         AnnotationDetailView.as_view(),

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -192,6 +192,23 @@ class AnnotationSearchView(GenericAPIView):
         return response
 
 
+class AnnotationRetireView(GenericAPIView):
+    """
+    Administrative functions for the notes service.
+    """
+
+    def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Delete all annotations for a user.
+        """
+        params = self.request.data
+        if 'user' not in params:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        Note.objects.filter(user_id=params['user']).delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 class AnnotationListView(GenericAPIView):
     """
         **Use Case**
@@ -369,17 +386,6 @@ class AnnotationListView(GenericAPIView):
         location = reverse('api:v1:annotations_detail', kwargs={'annotation_id': note.id})
         serializer = NoteSerializer(note)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers={'Location': location})
-
-    def delete(self, *args, **kwargs):  # pylint: disable=unused-argument
-        """
-        Delete all annotations for a user.
-        """
-        params = self.request.data
-        if 'user' not in params:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        Note.objects.filter(user_id=params['user']).delete()
-        return Response(status=status.HTTP_200_OK)
 
 
 class AnnotationDetailView(APIView):


### PR DESCRIPTION
This is a mitigation to the issue raised in LEARNER-6532 where
apparently buggy annotator.js code is calling the DELETE endpoint
without providing an annotation id.  Our annotator-compatible API
deviates from the documented annotator API in such a way that NOT
providing the annotation id implies delete (retire) all annotations.
    
The correct fix should be to additionally protect this API endpoint by
only authorizing the LMS, but renaming the endpoint is a sufficient
mitigation since annotator.js is far less likely to accidentally call
it.