### PR TITLE
ARCH-262: Reverts addition of JwtAuthCookieMiddleware

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -44,7 +44,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 INSTALLED_APPS = [


### PR DESCRIPTION
When JWT cookies are required, there will be some work needed to make this work.  
See "[ARCH-266: Backend: Enable JWT Cookies in remaining IDAs.](https://openedx.atlassian.net/browse/ARCH-266)"