### PR TITLE
[BB-724] Disable default BasicAuthentication 

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -66,6 +66,9 @@ WSGI_APPLICATION = 'notesserver.wsgi.application'
 LOGGING = get_logger_config()
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
         'notesapi.v1.permissions.HasAccessToken'
     ],


### PR DESCRIPTION
By default, BasicAuthentication is included as one of the ``DEFAULT_AUTHENTICATION_CLASSES``, and this is causing a problem with our setup which has the notes-api running behind HAProxy. 

When the platform is set up to require basic authentication and the header for the same is added to all API requests automatically, edx-notes-api tries to parse the header and match it an existing user account. This causes API requests to fail with an invalid username/password error. 

This PR explicitly sets the ``DEFAULT_AUTHENTICATION_CLASSES`` to exclude BasicAuthentication, since that is not used by this API. 

**Testing instructions**:

1. Install edx-notes-api
2. Set it up behind Nginx or another reverse proxy that requires authentication.
3. Try to access APIs that should work without an Authentication header. 
4. You should get an "invalid username/password error" with the master branch, but none with this branch. 

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD