### PR TITLE
make pii_report directory name consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .coverage
 .tox
 coverage/
+pii_report/
 
 # Sqlite Database
 *.db

--- a/.pii_annotations.yml
+++ b/.pii_annotations.yml
@@ -1,5 +1,5 @@
 source_path: ./
-report_path: pii_reports
+report_path: pii_report
 safelist_path: .annotation_safe_list.yml
 coverage_target: 100.0
 annotations:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test: clean
 		$(PACKAGES)
 
 pii_check: test.requirements pii_clean
-	code_annotations django_find_annotations --config_file .pii_annotations.yml --report_path pii_report/ \
+	code_annotations django_find_annotations --config_file .pii_annotations.yml \
 		--lint --report --coverage
 
 run:


### PR DESCRIPTION
The pii_* make targets use "pii_report" instead of "pii_reports".