### PR TITLE
Updated version restriction for Elasticsearch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ requests==2.9.1
 djangorestframework==3.6.3
 django-rest-swagger==2.1.2
 django-haystack==2.8.0
-elasticsearch>=1.0.0,<2.0.0
+elasticsearch>=1.0.0,<6.0
 django-cors-headers==2.4.0
 PyJWT==0.3.0
 MySQL-python==1.2.5  # GPL License


### PR DESCRIPTION
The current release of Django Haystack supports up through version 5.x of Elasticsearch so I updated the version pin in `setup.py` to reflect that fact.