### PR TITLE
Add username replacement API

### DIFF
--- a/notesapi/v1/permissions.py
+++ b/notesapi/v1/permissions.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import BasePermission
 
 logger = logging.getLogger(__name__)
 
+USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 class TokenWrongIssuer(Exception):
     pass
@@ -63,3 +64,11 @@ class HasAccessToken(BasePermission):
         except TokenWrongIssuer:
             logger.debug("Token has wrong issuer %s", token)
         return False
+
+class CanReplaceUsername(BasePermission):
+    """
+    Grants access to the Username Replacement API for anyone in the group,
+    including the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.groups.filter(name=USERNAME_REPLACEMENT_GROUP).exists()

--- a/notesapi/v1/permissions.py
+++ b/notesapi/v1/permissions.py
@@ -71,4 +71,4 @@ class CanReplaceUsername(BasePermission):
     including the service user.
     """
     def has_permission(self, request, view):
-        return request.user.groups.filter(name=USERNAME_REPLACEMENT_GROUP).exists()
+        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER")

--- a/notesapi/v1/urls.py
+++ b/notesapi/v1/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from notesapi.v1.views import AnnotationListView, AnnotationDetailView, AnnotationSearchView
+from notesapi.v1.views import AnnotationListView, AnnotationDetailView, AnnotationSearchView, UsernameReplacementView
 
 urlpatterns = [
     url(r'^annotations/$', AnnotationListView.as_view(), name='annotations'),
@@ -9,4 +9,5 @@ urlpatterns = [
         name='annotations_detail'
     ),
     url(r'^search/$', AnnotationSearchView.as_view(), name='annotations_search'),
+    url(r'replace_usernames/$', UsernameReplacementView.as_view(), name="replace_usernames")
 ]

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -519,9 +519,8 @@ class UsernameReplacementView(APIView):
     API will recieve a list of current usernames and their new username.
     """
 
-    # authentication_classes = (JwtAuthentication, )
-    # permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
-    permission_classes = (permissions.AllowAny, )
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
 
     def post(self, request):
         """

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -2,20 +2,25 @@ import json
 import logging
 
 import newrelic.agent
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import ugettext as _
-from rest_framework import status
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework import permissions, status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 
 from haystack.query import SQ
 from notesapi.v1.models import Note
 from notesapi.v1.serializers import (NotesElasticSearchSerializer,
                                      NoteSerializer)
+from notesapi.v1.permissions import CanReplaceUsername
 
 if not settings.ES_DISABLED:
     from notesserver.highlight import SearchQuerySet
@@ -504,3 +509,136 @@ class AnnotationDetailView(APIView):
 
         # Annotation deleted successfully.
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class UsernameReplacementView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken.
+
+    API will recieve a list of current usernames and their new username.
+    """
+
+    # authentication_classes = (JwtAuthentication, )
+    # permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+    permission_classes = (permissions.AllowAny, )
+
+    def post(self, request):
+        """
+        **POST Parameters**
+
+        A POST request must include the following parameter.
+
+        * username_mappings: Required. A list of objects that map the current username (key)
+          to the new username (value)
+            {
+                "username_mappings": [
+                    {"current_username_1": "new_username_1"},
+                    {"current_username_2": "new_username_2"}
+                ]
+            }
+
+        **POST Response Values**
+
+        As long as data validation passes, the request will return a 200 with a new mapping
+        of old usernames (key) to new username (value)
+
+        {
+            "successful_replacements": [
+                {"old_username_1": "new_username_1"}
+            ],
+            "failed_replacements": [
+                {"old_username_2": "new_username_2"}
+            ]
+        }
+
+        TODO: Determine if we need an audit trail outside of logging and API response.
+        """
+
+        # (model_name, column_name)
+        MODELS_WITH_USERNAME = (
+            ('auth.user', 'username'),
+        )
+
+        username_mappings = request.data.get("username_mappings")
+        replacement_locations = self._load_models(MODELS_WITH_USERNAME)
+
+        if not self._has_valid_schema(username_mappings):
+            raise ValidationError("Request data does not match schema")
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            new_username = list(username_pair.values())[0]
+            successfully_replaced = self._replace_username_for_all_models(
+                current_username,
+                new_username,
+                replacement_locations
+            )
+            if successfully_replaced:
+                successful_replacements.append({current_username: new_username})
+            else:
+                failed_replacements.append({current_username: new_username})
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "successful_replacements": successful_replacements,
+                "failed_replacements": failed_replacements
+            }
+        )
+
+    def _load_models(self, models_with_fields):
+        """ Takes tuples that contain a model path and returns the list with a loaded version of the model """
+        try:
+            replacement_locations = [(apps.get_model(model), column) for (model, column) in models_with_fields]
+        except LookupError:
+            log.exception("Unable to load models for username replacement")
+            raise
+        return replacement_locations
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True
+
+    def _replace_username_for_all_models(self, current_username, new_username, replacement_locations):
+        """
+        Replaces current_username with new_username for all (model, column) pairs in replacement locations.
+        Returns if it was successful or not. Will return successful even if no matching
+
+        TODO: Determine if logs of username are a PII issue.
+        """
+        try:
+            with transaction.atomic():
+                num_rows_changed = 0
+                for (model, column) in replacement_locations:
+                    num_rows_changed += model.objects.filter(
+                        **{column: current_username}
+                    ).update(
+                        **{column: new_username}
+                    )
+        except Exception as exc:
+            log.exception("Unable to change username from {current} to {new}. Reason: {error}".format(
+                current=current_username,
+                new=new_username,
+                error=exc
+            ))
+            return False
+        if num_rows_changed == 0:
+            log.warning("Unable to change username from {current} to {new} because {current} doesn't exist.".format(
+                current=current_username,
+                new=new_username,
+            ))
+            return False
+
+        log.info("Successfully changed username from {current} to {new}.".format(
+            current=current_username,
+            new=new_username,
+        ))
+        return True
+


### PR DESCRIPTION
New API replaces all copies of username in this service with a new
username. Requires user be in a username_replacement_admin group. Should
only be ran as a larger job to update usernames across all services,
otherwise the system will be left in a broken state for those users.