### PR TITLE
Revert "Revert "[BB-724] Disable default BasicAuthentication ""

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -66,6 +66,9 @@ WSGI_APPLICATION = 'notesserver.wsgi.application'
 LOGGING = get_logger_config()
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
         'notesapi.v1.permissions.HasAccessToken'
     ],


### PR DESCRIPTION
Reverts edx/edx-notes-api#93 (which reverted #85). The changes in #85 were originally reverted because we thought they were responsible for an auth related error prevented us from deploying the notes API. However, we continued to see the same issue after reverting. Since this wasn't the root of the problem, I'm reverting the revert (i.e. putting the original contribution back into master).