### PR TITLE
Update devstack client name and secret to match what gets provisioned.

### DIFF
--- a/notesserver/settings/devstack.py
+++ b/notesserver/settings/devstack.py
@@ -9,8 +9,8 @@ LOG_SETTINGS_DEV_ENV = True
 ALLOWED_HOSTS = ['*']
 
 # These values are derived from provision-ida-user.sh in the edx/devstack repo.
-CLIENT_ID = 'edx_notes_api-key'
-CLIENT_SECRET = 'edx_notes_api-secret'
+CLIENT_ID = 'edx_notes_api-backend-service-key'
+CLIENT_SECRET = 'edx_notes_api-backend-service-secret'
 
 ES_INDEXES = {'default': 'notes_index'}
 HAYSTACK_CONNECTIONS['default']['URL'] = 'http://edx.devstack.elasticsearch:9200/'


### PR DESCRIPTION
The devstack provisioning scripts add a client id and secret to the database.  We were using different information, causing authentication to fail.