### PR TITLE
Django 2.2 compatibility changes.

### DIFF
--- a/notesapi/urls.py
+++ b/notesapi/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import include, url
 
+app_name = "notesapi.v1"
+
 urlpatterns = [
     url(r'^v1/', include('notesapi.v1.urls', namespace='v1')),
 ]

--- a/notesapi/v1/tests/test_update_index.py
+++ b/notesapi/v1/tests/test_update_index.py
@@ -3,7 +3,7 @@ from unittest import skipIf
 
 from django.conf import settings
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import signals
 
 import factory

--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import jwt
 from django.conf import settings
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase

--- a/notesapi/v1/urls.py
+++ b/notesapi/v1/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from notesapi.v1.views import (AnnotationDetailView, AnnotationListView,
                                AnnotationRetireView, AnnotationSearchView)
-
+app_name = "notesapi.v1"
 urlpatterns = [
     url(r'^annotations/$', AnnotationListView.as_view(), name='annotations'),
     url(r'^retire_annotations/$', AnnotationRetireView.as_view(), name='annotations_retire'),

--- a/notesapi/v1/views.py
+++ b/notesapi/v1/views.py
@@ -4,7 +4,7 @@ import logging
 import newrelic.agent
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.utils.translation import ugettext as _
 from haystack.query import SQ

--- a/notesserver/test_views.py
+++ b/notesserver/test_views.py
@@ -3,7 +3,7 @@ import json
 from unittest import skipIf
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from elasticsearch.exceptions import TransportError
 from rest_framework.test import APITestCase
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
-Django<=2.0
+Django>=1.11,<2.3
 requests==2.9.1
-djangorestframework==3.6.3
+djangorestframework
 django-rest-swagger==2.1.2
 django-haystack==2.8.0
 elasticsearch>=1.0.0,<2.0.0
@@ -11,6 +11,6 @@ gunicorn==19.1.1     # MIT
 path.py==3.0.1
 python-dateutil==2.4.0
 newrelic==4.8.0.110            # New Relic
-edx-django-release-util==0.3.1
-edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+edx-django-release-util
+edx-django-utils
+edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,10 +12,10 @@ django-rest-swagger==2.1.2
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.26
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.6.3
-edx-django-release-util==0.3.1
-edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+djangorestframework==3.10.3
+edx-django-release-util==0.3.2
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
 elasticsearch==1.9.0
 future==0.18.2            # via pyjwkest
@@ -23,11 +23,11 @@ gunicorn==19.1.1
 itypes==1.1.0             # via coreapi
 jinja2==2.10.3            # via coreschema
 markupsafe==1.1.1         # via jinja2
-mysqlclient==1.4.5
+mysqlclient==1.4.6
 newrelic==4.8.0.110
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==3.0.1
-pbr==5.4.3                # via stevedore
+pbr==5.4.4                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.9.4      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -35,10 +35,10 @@ pyjwt==1.7.1
 pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.4.0
 pytz==2019.3              # via django
-pyyaml==5.1.2             # via edx-django-release-util
+pyyaml==5.2               # via edx-django-release-util
 requests==2.9.1
 rest-condition==1.0.3     # via edx-drf-extensions
-semantic-version==2.8.2   # via edx-drf-extensions
+semantic-version==2.8.3   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
 six==1.13.0               # via edx-django-release-util, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
 stevedore==1.31.0         # via edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,8 +11,8 @@ colorama==0.4.1           # via pylint
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.4
-ddt==1.2.1
-diff-cover==2.4.0
+ddt==1.2.2
+diff-cover==2.4.1
 django-cors-headers==2.4.0
 django-haystack==2.8.0
 django-nose==1.4.6
@@ -20,17 +20,17 @@ django-rest-swagger==2.1.2
 django-waffle==0.18.0
 django==1.11.26
 djangorestframework-jwt==1.11.0
-djangorestframework==3.6.3
-edx-django-release-util==0.3.1
-edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+djangorestframework==3.10.3
+edx-django-release-util==0.3.2
+edx-django-utils==2.0.2
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1
 elasticsearch==1.9.0
 factory-boy==2.12.0
-faker==2.0.4              # via factory-boy
+faker==3.0.0              # via factory-boy
 future==0.18.2
 gunicorn==19.1.1
-importlib-metadata==0.23  # via inflect
+importlib-metadata==1.2.0  # via inflect
 inflect==3.0.2            # via jinja2-pluralize
 itypes==1.1.0
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -39,18 +39,18 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1
 mock==3.0.5
 more-itertools==5.0.0
-mysqlclient==1.4.5
+mysqlclient==1.4.6
 newrelic==4.8.0.110
 nose-exclude==0.5.0
 nose-ignore-docstring==0.2
 nose==1.3.7               # via django-nose, nose-exclude
 openapi-codec==1.3.2
 path.py==3.0.1
-pbr==5.4.3
+pbr==5.4.4
 pep8==1.7.1
 psutil==1.2.1
 pycryptodomex==3.9.4
-pygments==2.4.2           # via diff-cover
+pygments==2.5.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pylint==1.5.0
@@ -58,10 +58,10 @@ pymongo==3.9.0
 python-dateutil==2.4.0
 python-slugify==4.0.0     # via code-annotations
 pytz==2019.3
-pyyaml==5.1.2
+pyyaml==5.2
 requests==2.9.1
 rest-condition==1.0.3
-semantic-version==2.8.2
+semantic-version==2.8.3
 simplejson==3.17.0
 six==1.13.0
 stevedore==1.31.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,23 +4,23 @@
 #
 #    make upgrade
 #
-certifi==2019.9.11        # via requests
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via pluggy, tox
-more-itertools==7.2.0     # via zipp
+importlib-metadata==1.2.0  # via pluggy, tox
+more-itertools==8.0.0     # via zipp
 packaging==19.2           # via tox
-pluggy==0.13.0            # via tox
+pluggy==0.13.1            # via tox
 py==1.8.0                 # via tox
 pyparsing==2.4.5          # via packaging
 requests==2.22.0          # via codecov
 six==1.13.0               # via packaging, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.14.1
+tox==3.14.2
 urllib3==1.25.7           # via requests
-virtualenv==16.7.7        # via tox
+virtualenv==16.7.8        # via tox
 zipp==0.6.0               # via importlib-metadata


### PR DESCRIPTION
This PR updates code to be compatibile with django 2.2.  We will still be running with django 1.11 at this time, until the edx-drf-extensions and code-annotations packages are upgraded.