### PR TITLE
upgrade ubuntu to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
     libssl-dev \
     build-essential \
     python3.8-dev \
+    python3.8-distutils \
     python3.8-venv -qy && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix Dockerfile to build docker image when ubuntu was changed from bionic to focul in PR: https://github.com/edx/edx-notes-api/pull/214
