### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ You can discuss this code on the `edx-code Google Group`__ or in the
 
 __ https://groups.google.com/forum/#!forum/edx-code
 
-.. |build-status| image:: https://travis-ci.org/edx/edx-notes-api.svg?branch=master
-   :target: https://travis-ci.org/edx/edx-notes-api
+.. |build-status| image:: https://travis-ci.com/edx/edx-notes-api.svg?branch=master
+   :target: https://travis-ci.com/edx/edx-notes-api
 .. |coverage-status| image:: https://coveralls.io/repos/edx/edx-notes-api/badge.png?branch=master
    :target: https://coveralls.io/r/edx/edx-notes-api?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 