### PR TITLE
Upgrade Django to 2.2.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ django-elasticsearch-dsl==7.1.4  # via -r requirements/base.in, django-elasticse
 django-nine==0.2.3        # via django-elasticsearch-dsl-drf
 django-rest-swagger==2.1.2  # via -r requirements/base.in
 django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.12.1  # via -r requirements/base.in, django-elasticsearch-dsl-drf, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via edx-drf-extensions
 edx-django-release-util==0.4.4  # via -r requirements/base.in

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition


### PR DESCRIPTION
This is to make sure that we use the same Django version for all applications.

This PR should be merged in time for the Koa release (cc @nedbat); it is ready for review.