### PR TITLE
Upgrade Django to 2.2.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django-cors-headers==3.4.0  # via -r requirements/base.in
 django-haystack==2.8.0    # via -r requirements/base.in
 django-rest-swagger==2.1.2  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-haystack, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-haystack, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-django-release-util==0.4.4  # via -r requirements/base.in

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-haystack, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-haystack, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition


### PR DESCRIPTION
This is to make sure that we use the same Django version for all applications.

This is ready for review -- cc @nedbat 