### PR TITLE
PSRE-981 | Upgrade urllib3 due to Dependbot alert

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django
-requests==2.22.0
+requests==2.25.0
 djangorestframework
 django-rest-swagger==2.1.2
 elasticsearch>=7.8,<8.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==3.4.7
+cryptography==3.4.8
     # via pyjwt
 django==2.2.24
     # via
@@ -41,9 +41,9 @@ django-elasticsearch-dsl==7.2.0
     # via
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf
-django-elasticsearch-dsl-drf==0.22.1
+django-elasticsearch-dsl-drf==0.22.2
     # via -r requirements/base.in
-django-nine==0.2.4
+django-nine==0.2.5
     # via django-elasticsearch-dsl-drf
 django-rest-swagger==2.1.2
     # via -r requirements/base.in
@@ -63,7 +63,7 @@ drf-jwt==1.19.1
     # via edx-drf-extensions
 edx-django-release-util==1.1.0
     # via -r requirements/base.in
-edx-django-utils==4.2.0
+edx-django-utils==4.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -87,7 +87,7 @@ future==0.18.2
     # via pyjwkest
 gunicorn==20.1.0
     # via -r requirements/base.in
-idna==2.8
+idna==2.10
     # via requests
 itypes==1.2.0
     # via coreapi
@@ -131,7 +131,7 @@ pytz==2021.1
     # via django
 pyyaml==5.4.1
     # via edx-django-release-util
-requests==2.22.0
+requests==2.25.0
     # via
     #   -r requirements/base.in
     #   coreapi
@@ -141,7 +141,7 @@ rest-condition==1.0.3
     # via edx-drf-extensions
 semantic-version==2.8.5
     # via edx-drf-extensions
-simplejson==3.17.4
+simplejson==3.17.5
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -160,7 +160,7 @@ stevedore==3.4.0
     #   edx-opaque-keys
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.25.11
+urllib3==1.26.6
     # via
     #   elasticsearch
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,13 +45,13 @@ coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
 ddt==1.4.2
     # via -r requirements/test.in
-diff-cover==6.3.3
+diff-cover==6.3.5
     # via -r requirements/test.in
 distlib==0.3.2
     # via virtualenv
@@ -76,9 +76,9 @@ django-elasticsearch-dsl==7.2.0
     # via
     #   -r requirements/base.txt
     #   django-elasticsearch-dsl-drf
-django-elasticsearch-dsl-drf==0.22.1
+django-elasticsearch-dsl-drf==0.22.2
     # via -r requirements/base.txt
-django-nine==0.2.4
+django-nine==0.2.5
     # via
     #   -r requirements/base.txt
     #   django-elasticsearch-dsl-drf
@@ -103,7 +103,7 @@ drf-jwt==1.19.1
     #   edx-drf-extensions
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.2.0
+edx-django-utils==4.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -125,7 +125,7 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl-drf
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.12.0
+faker==8.12.1
     # via factory-boy
 filelock==3.0.12
     # via
@@ -137,7 +137,7 @@ future==0.18.2
     #   pyjwkest
 gunicorn==20.1.0
     # via -r requirements/base.txt
-idna==2.8
+idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
@@ -255,7 +255,7 @@ pyyaml==5.4.1
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-requests==2.22.0
+requests==2.25.0
     # via
     #   -r requirements/base.txt
     #   coreapi
@@ -269,7 +269,7 @@ semantic-version==2.8.5
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.17.4
+simplejson==3.17.5
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -313,7 +313,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==1.25.11
+urllib3==1.26.6
     # via
     #   -r requirements/base.txt
     #   elasticsearch

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -26,7 +26,7 @@ packaging==21.0
     # via tox
 platformdirs==2.2.0
     # via virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via tox
 py==1.10.0
     # via tox


### PR DESCRIPTION
According to dependbot urllib3 version should be >= 1.26.5
For this we have to upgrade requests module to 2.25 as it is the least version that supports urllib3=1.26 version.
Reference: https://docs.python-requests.org/en/master/community/updates/#:~:text=2.25.0%20(2020-11,in%20Requests%20v2.26.0.