### PR TITLE
Downgrade Elastic Search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,21 @@ develop: test.requirements
 piptools: ## install pinned version of pip-compile and pip-sync
 	pip install -r requirements/pip-tools.txt
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: piptools ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT) piptools ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+	sed 's/pyjwt\[crypto\]<2.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/social-auth-core<4.0.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/edx-auth-backends<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/edx-drf-extensions<7.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,6 +22,7 @@ cryptography==3.4.8
     # via pyjwt
 django==2.2.24
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-cors-headers
@@ -59,8 +60,10 @@ djangorestframework==3.12.4
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.19.1
-    # via edx-drf-extensions
+drf-jwt==1.19.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   edx-drf-extensions
 edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-utils==4.3.0
@@ -73,8 +76,9 @@ edx-drf-extensions==6.6.0
     #   -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
-elasticsearch==7.14.0
+elasticsearch==7.13.4
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf
     #   elasticsearch-dsl

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,47 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# latest version is causing e2e failures in edx-platform.
+# See  comment.
+drf-jwt<1.19.1
+
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
+
+
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
+
+
+# PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
+# actively working to fix. A number of the active constraints are all related
+# to this effort. Additionally, your IDA/service may also be affected directly
+# by these changes. You should not upgrade without knowing what you are doing.
+
+
+# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
+social-auth-app-django<5.0.0
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
+# See  comment.
+
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+# pluggy released 1.0.0, but pytest limits to <1.0.0 and tox does not, so they disagree on the version to use.
+# This pin can be removed once pytest ships 6.2.5 which will remove the upper limit on the pluggy version.
+pluggy<1.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,11 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# We are creating a local copy of the common constraints file and override/remove the global constraint which we don't need.
+# This approach is used temporarily and will be improved in https://openedx.atlassian.net/browse/BOM-2721
+# This file contains all common constraints for edx-repos
+-c common_constraints.txt
+
 # Stay on latest LTS release
 Django>=2.2,<3.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -97,7 +97,7 @@ djangorestframework==3.12.4
     #   drf-jwt
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.19.1
+drf-jwt==1.19.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -113,7 +113,7 @@ edx-opaque-keys==2.2.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-elasticsearch==7.14.0
+elasticsearch==7.13.4
     # via
     #   -r requirements/base.txt
     #   django-elasticsearch-dsl-drf
@@ -188,7 +188,7 @@ pbr==5.6.0
     #   stevedore
 pep8==1.7.1
     # via -r requirements/test.in
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
 pluggy==0.13.1
     # via
@@ -229,7 +229,7 @@ pymongo==3.12.0
     #   edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.in
     #   pytest-cov

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -24,7 +24,7 @@ idna==3.2
     # via requests
 packaging==21.0
     # via tox
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
 pluggy==1.0.0
     # via tox


### PR DESCRIPTION
Elasticsearch 7.14.0 has introduced breaking changes which might be causing failure on deployment pipeline. So we are downgrading.

https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html#release-notes-7-14-0-enterprise-search-bug-fixes